### PR TITLE
Automatically fetch custom favicons

### DIFF
--- a/src/bridges/settings.ts
+++ b/src/bridges/settings.ts
@@ -16,6 +16,13 @@ const settingsBridge = {
         ipcRenderer.invoke("set-menu", state)
     },
 
+    getIconStatus: (): boolean => {
+        return ipcRenderer.sendSync("get-icon-status")
+    },
+    toggleIconStatus: () => {
+        ipcRenderer.send("toggle-icon-status")
+    },
+
     getProxyStatus: (): boolean => {
         return ipcRenderer.sendSync("get-proxy-status")
     },

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -3,7 +3,7 @@ import intl from "react-intl-universal"
 import { urlTest, byteToMB, calculateItemSize, getSearchEngineName } from "../../scripts/utils"
 import { ThemeSettings, SearchEngines } from "../../schema-types"
 import { getThemeSettings, setThemeSettings, exportAll } from "../../scripts/settings"
-import { Stack, Label, Toggle, TextField, DefaultButton, ChoiceGroup, IChoiceGroupOption, loadTheme, Dropdown, IDropdownOption, PrimaryButton } from "@fluentui/react"
+import { Stack, Label, Toggle, TextField, DefaultButton, ChoiceGroup, IChoiceGroupOption, loadTheme, Dropdown, IDropdownOption, PrimaryButton, ToggleBase } from "@fluentui/react"
 import DangerButton from "../utils/danger-button"
 
 type AppTabProps = {
@@ -20,6 +20,7 @@ type AppTabState = {
     itemSize: string
     cacheSize: string
     deleteIndex: string
+    iconStatus: boolean
 }
 
 class AppTab extends React.Component<AppTabProps, AppTabState> {
@@ -31,7 +32,8 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
             themeSettings: getThemeSettings(),
             itemSize: null,
             cacheSize: null,
-            deleteIndex: null
+            deleteIndex: null,
+            iconStatus: window.settings.getIconStatus()
         }
         this.getItemSize()
         this.getCacheSize()
@@ -71,6 +73,11 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
     ]
     onFetchIntervalChanged = (item: IDropdownOption) => {
         this.props.setFetchInterval(item.key as number)
+    }
+
+    toggleIcon = () => {
+        window.settings.toggleIconStatus()
+        this.setState({ iconStatus: window.settings.getIconStatus() })
     }
 
     searchEngineOptions = (): IDropdownOption[] => [
@@ -182,6 +189,13 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                         style={{width: 200}} />
                 </Stack.Item>
             </Stack>
+
+            <Toggle
+                label="Use custom icons when available"
+                checked={this.state.iconStatus}
+                onText="Enabled"
+                offText="Disabled"
+                onChanged={this.toggleIcon} />
 
             <Stack horizontal verticalAlign="baseline">
                 <Stack.Item grow>

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -16,6 +16,9 @@ else if (process.platform === "win32") app.setAppUserModelId("me.hyliu.fluentrea
 
 let restarting = false
 
+// Usage of any user agent will promt youtube to redirect url, causing issues reading response
+app.userAgentFallback = " "
+
 function init() {
     performUpdate(store)
     nativeTheme.themeSource = store.get("theme", ThemeSettings.Default)

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -22,6 +22,15 @@ ipcMain.handle("set-menu", (_, state: boolean) => {
     store.set(MENU_STORE_KEY, state)
 })
 
+
+const ICON_STATUS_KEY = "customIcon"
+function getIconStatus() {
+    return store.get(ICON_STATUS_KEY, true)
+}
+function toggleIconStatus() {
+    store.set(ICON_STATUS_KEY, !getIconStatus())
+}
+
 const PAC_STORE_KEY = "pac"
 const PAC_STATUS_KEY = "pacOn"
 function getProxyStatus() {
@@ -46,6 +55,13 @@ function setProxy(address = null) {
         session.fromPartition("sandbox").setProxy(rules)
     }
 }
+ipcMain.on("get-icon-status", (event) => {
+    event.returnValue = getIconStatus()
+})
+ipcMain.on("toggle-icon-status", () => {
+    toggleIconStatus()
+})
+
 ipcMain.on("get-proxy-status", (event) => {
     event.returnValue = getProxyStatus()
 })

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -78,4 +78,5 @@ export type SchemaTypes = {
     filterType: number
     listViewConfigs: ViewConfigs
     useNeDB: boolean
+    customIcon: boolean
 }

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -2,7 +2,7 @@ import Parser from "@yang991178/rss-parser"
 import intl from "react-intl-universal"
 import * as db from "../db"
 import lf from "lovefield"
-import { fetchFavicon, ActionStatus, AppThunk, parseRSS } from "../utils"
+import { fetchFavicon, fetchYTChannelIcon, ActionStatus, AppThunk, parseRSS } from "../utils"
 import { RSSItem, insertItems, ItemActionTypes, FETCH_ITEMS, MARK_READ, MARK_UNREAD, MARK_ALL_READ } from "./item"
 import { saveSettings } from "./app"
 import { SourceRule } from "./rule"
@@ -322,8 +322,8 @@ export function updateFavicon(sids?: number[], force=false): AppThunk<Promise<vo
         }
         const promises = sids.map(async sid => {
             const url = initSources[sid].url
-            let favicon = (await fetchFavicon(url)) || ""
             const source = getState().sources[sid]
+            let favicon = (await fetchFavicon(url)) || ""
             if (source && source.url === url && (force || source.iconurl === undefined)) {
                 source.iconurl = favicon
                 await dispatch(updateSource(source))

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -74,8 +74,33 @@ export async function parseRSS(url: string) {
 
 export const domParser = new DOMParser()
 
+export async function fetchYTChannelIcon(url: string) {
+    let channelId = url.split("=")[1]
+    url = url.split("/").slice(0, 3).join("/")
+    let channelUrl = url + '/channel/' + channelId
+    let result = await fetch(channelUrl, { credentials: 'omit', })
+    if (result.ok) {
+        let html = await result.text()
+        let dom = domParser.parseFromString(html, "text/html")
+        let links = dom.getElementsByTagName("link")
+        for (let link of links) {
+            let rel = link.getAttribute("rel")
+            if (rel === "image_src" && link.hasAttribute("href")) {
+                let href = link.getAttribute("href")
+                return href.replace("=s900", "=s16")
+            }
+        }
+    }
+}
+
 export async function fetchFavicon(url: string) {
     try {
+        const customIcon = window.settings.getIconStatus()
+        if (customIcon) {
+            if (Url.parse(url).host === "www.youtube.com" && url.includes("channel")) {
+                return fetchYTChannelIcon(url)
+            }
+        }
         url = url.split("/").slice(0, 3).join("/")
         let result = await fetch(url, { credentials: "omit" })
         if (result.ok) {

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -89,6 +89,7 @@ export async function fetchFavicon(url: string) {
                     let parsedUrl = Url.parse(url)
                     if (href.startsWith("//")) return parsedUrl.protocol + href
                     else if (href.startsWith("/")) return url + href
+                    else if (href.startsWith("favicon")) return url + '/' + href
                     else return href
                 }
             }


### PR DESCRIPTION
Added option in preferences to use 'custom icons when available'.
This is meant to be a modular feature which automatically fetches images (favicons) if user doesn't wish to use the default one.

YouTube is an example, where instead of the YouTube logo, the new functionally makes a new request to the users channel (only channel feed, not playlists) and pulls the avatar image.

Only YouTube is currently supported, but more modules can easily be added in scripts/utils.ts

The modular functionality would benefit from a rework, but this build is and stable working.

![preferences](https://user-images.githubusercontent.com/33367405/129472384-01c5f243-ed6b-4960-8496-18d34a6025c8.png)

Also added some minor changes to fetch default favicon.